### PR TITLE
remove deprecated args method on gitleaks job in CI

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    
+  workflow_dispatch: {}
 
 permissions:
   contents: read

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -76,11 +76,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 1 # Check Last Commit 
 
       - name: Run Gitleaks Secret Scan
         uses: gitleaks/gitleaks-action@v2
-        with:
-          args: detect --source . --no-git --redact --exit-code 1
         continue-on-error: true
 
   # 4) Run CodeQL security analysis


### PR DESCRIPTION
<img width="974" height="341" alt="image" src="https://github.com/user-attachments/assets/9e155a73-92a8-4445-9c68-870b1a8d8955" />

-------

<img width="956" height="140" alt="image" src="https://github.com/user-attachments/assets/2f07288d-0678-46f6-b253-45019273550d" />

